### PR TITLE
Enable to select Rubocop to use for analysis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,62 @@ jobs:
             bundle add rubocop
       - dscar/analyze:
           should-use-bundler: true
+  integration-test-3:
+    executor:
+      <<: *dscar-default-executor
+    steps:
+      - checkout
+      - run:
+          name: setup
+          command: |
+            cat \<<-"EOT" > Gemfile
+            # frozen_string_literal: true
+
+            source "https://rubygems.org"
+
+            git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+            # gem "rails"
+
+            gem "rubocop", "= 0.80.0"
+            EOT
+
+            cat \<<-"EOT" > Gemfile.lock
+            GEM
+              remote: https://rubygems.org/
+              specs:
+                ast (2.4.0)
+                jaro_winkler (1.5.4)
+                parallel (1.19.1)
+                parser (2.7.1.0)
+                  ast (~> 2.4.0)
+                rainbow (3.0.0)
+                rexml (3.2.4)
+                rubocop (0.80.0)
+                  jaro_winkler (~> 1.5.1)
+                  parallel (~> 1.10)
+                  parser (>= 2.7.0.1)
+                  rainbow (>= 2.2.2, < 4.0)
+                  rexml
+                  ruby-progressbar (~> 1.7)
+                  unicode-display_width (>= 1.4.0, < 1.7)
+                ruby-progressbar (1.10.1)
+                unicode-display_width (1.6.1)
+
+            PLATFORMS
+              ruby
+
+            DEPENDENCIES
+              rubocop (= 0.80.0)
+
+            BUNDLED WITH
+              1.17.2
+            EOT
+      - dscar/install-analyzer
+      - run:
+          name: evaluate
+          command: |
+            test "$(rubocop --version)" == "0.80.0"
 
 workflows:
   lint_pack-validate_publish-dev:
@@ -80,4 +136,5 @@ workflows:
     jobs:
       - integration-test-1
       - integration-test-2
+      - integration-test-3
     when: << pipeline.parameters.run-integration-tests >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,19 @@ jobs:
     steps:
       - checkout
       - dscar/analyze
+  integration-test-2:
+    executor:
+      <<: *dscar-default-executor
+    steps:
+      - checkout
+      - run:
+          name: setup
+          command: |
+            set -x
+            bundle init
+            bundle add rubocop
+      - dscar/analyze:
+          should-use-bundler: true
 
 workflows:
   lint_pack-validate_publish-dev:
@@ -66,4 +79,5 @@ workflows:
   integration-tests:
     jobs:
       - integration-test-1
+      - integration-test-2
     when: << pipeline.parameters.run-integration-tests >>

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,12 @@ integration-test-1: .circleci/compiled-config.yml
 integration-test-2: .circleci/compiled-config.yml
 	circleci local execute -c $< --job $@
 
+.PHONY: integration-test-3
+integration-test-3: .circleci/compiled-config.yml
+	circleci local execute -c $< --job $@
+
 .PHONY: integration-test
 integration-test: \
 	integration-test-1 \
-	integration-test-2
+	integration-test-2 \
+	integration-test-3

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,17 @@ create:
 
 .INTERMEDIATE: .circleci/compiled-config.yml
 .circleci/compiled-config.yml: publish
-	circleci config process .circleci/config.yml >.circleci/compiled-config.yml
+	circleci config process .circleci/config.yml > $@
 
 .PHONY: integration-test-1
 integration-test-1: .circleci/compiled-config.yml
-	circleci local execute -c .circleci/compiled-config.yml --job integration-test-1
+	circleci local execute -c $< --job $@
+
+.PHONY: integration-test-2
+integration-test-2: .circleci/compiled-config.yml
+	circleci local execute -c $< --job $@
+
+.PHONY: integration-test
+integration-test: \
+	integration-test-1 \
+	integration-test-2

--- a/src/commands/analyze.yml
+++ b/src/commands/analyze.yml
@@ -47,23 +47,33 @@ parameters:
     description: Specify the maximum number of processes to run at the same time
     type: integer
     default: 1
+  should-use-bundler:
+    description: Specify true if you want to perform analysis using Bundler
+    type: boolean
+    default: false
 steps:
   - when:
-      condition: << parameters.analysis-command-version >>
+      condition: << parameters.should-use-bundler >>
       steps:
         - dscar/analyze: &analyze
             step-name: Analyze code statically using Rubocop
             analysis-name: Rubocop
-            analysis-command: rubocop
+            analysis-command: bundle
             analysis-arguments: |
-                    _<< parameters.analysis-command-version >>_
-                    << parameters.analysis-arguments >>
-                    -f json
-                    -C false
-                    --force-exclusion
+              exec
+              rubocop
+              << parameters.analysis-arguments >>
+              -f json
+              -C false
+              --force-exclusion
             error-pattern: << parameters.error-pattern >>
             transformation-command: jq
             prepare:
+              - steps: << parameters.prepare >>
+              - when:
+                  condition: << parameters.should-use-bundler >>
+                  steps:
+                    - run: bundle install
               - run: sudo apt-get install jq
               - run:
                   name: export TRANSFORMATION_ARGUMENTS
@@ -81,7 +91,6 @@ steps:
                     )"
                     declare -ax TRANSFORMATION_ARGUMENTS=( -srM "$FILTER" )
                     echo "$(declare -p TRANSFORMATION_ARGUMENTS)" >> $BASH_ENV
-              - steps: << parameters.prepare >>
             should-find: "true"
             starting-points: << parameters.starting-points >>
             patterns-to-include: << parameters.patterns-to-include >>
@@ -91,11 +100,27 @@ steps:
             redirecting-output: << parameters.redirecting-output >>
             max-procs: << parameters.max-procs >>
   - unless:
-      condition: << parameters.analysis-command-version >>
+      condition: << parameters.should-use-bundler >>
       steps:
-        - dscar/analyze:
-            <<: *analyze
-            analysis-arguments: |
+        - when:
+            condition: << parameters.analysis-command-version >>
+            steps:
+              - dscar/analyze:
+                  <<: *analyze
+                  analysis-command: rubocop
+                  analysis-arguments: |
+                    _<< parameters.analysis-command-version >>_
+                    << parameters.analysis-arguments >>
+                    -f json
+                    -C false
+                    --force-exclusion
+        - unless:
+            condition: << parameters.analysis-command-version >>
+            steps:
+              - dscar/analyze:
+                  <<: *analyze
+                  analysis-command: rubocop
+                  analysis-arguments: |
                     << parameters.analysis-arguments >>
                     -f json
                     -C false

--- a/src/commands/install-analyzer.yml
+++ b/src/commands/install-analyzer.yml
@@ -1,3 +1,16 @@
 description: Install Rubocop
 steps:
-  - run: sudo gem install rubocop rubocop-performance rubocop-rails
+  - run:
+      name: Install Rubocop
+      command: |
+        set -x
+        if [ -e 'Gemfile.lock' ]
+        then
+          {
+            grep '^\s\{4\}rubocop\b' |
+            sed -e 's/^\s\{4\}\(rubocop\b\S*\) (\(.*\))$/\1:\2/'
+          } < Gemfile.lock
+        else
+          echo rubocop rubocop-performance rubocop-rails
+        fi |
+        xargs -t sudo gem install


### PR DESCRIPTION
Add the following logic to allow user to select the Rubocop to use for analysis.

- If the `should-use-bundler` parameter is `true`, execute `bundle exec rubocop` (assuming it has been done until `bundle install`)
- If `false`, execute `rubocop` command
- The version of Rubocop to run is determined as follows:
    - If Gemfile.lock exists, determine the version from that
    - Otherwise, use the latest version
- If you want a specific version of Rubocop, specify it with the `analysis-command-version` parameter